### PR TITLE
Unify synthetic ticker prefixes to _SYN:

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ setPreference("accounts.hideInactive", true);
 ```
 Keys should be namespaced by page/feature (e.g., `accounts.hideInactive`). The hook loads all preferences on mount, applies optimistic updates, and rolls back on API errors. Prefer this over `useState` for any toggle, filter, or setting the user would expect to survive a refresh.
 
-**Synthetic Tickers:** The backend generates synthetic ticker identifiers for holdings that aren't tradable securities (format: `_SF:{hash}` for SimpleFIN, `_MAN:{hash}` for manual "Other" holdings). These are internal identifiers and should NOT be displayed to users in UI views. Use the `isSyntheticTicker()` utility from `@/utils/ticker` to detect and hide them. Show only the security name for synthetic tickers. Exception: Admin/settings pages like SecurityList may show all tickers for management purposes.
+**Synthetic Tickers:** The backend generates synthetic ticker identifiers for holdings that aren't tradable securities (format: `_SYN:{hash}` — unified prefix for all providers and manual holdings). These are internal identifiers and should NOT be displayed to users in UI views. Use the `isSyntheticTicker()` utility from `@/utils/ticker` to detect and hide them. Show only the security name for synthetic tickers. Exception: Admin/settings pages like SecurityList may show all tickers for management purposes.
 
 ## File Locations
 

--- a/backend/alembic/versions/47d93799292c_unify_synthetic_ticker_prefixes_to__syn.py
+++ b/backend/alembic/versions/47d93799292c_unify_synthetic_ticker_prefixes_to__syn.py
@@ -1,0 +1,42 @@
+"""unify synthetic ticker prefixes to _SYN
+
+Revision ID: 47d93799292c
+Revises: f9b3df5f0ef2
+Create Date: 2026-02-23 20:07:36.491854
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = '47d93799292c'
+down_revision: Union[str, Sequence[str], None] = 'f9b3df5f0ef2'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Old prefixes and their lengths (for SUBSTR offset, 1-based)
+_OLD_PREFIXES = [
+    ("_SF:", 5),       # len("_SF:") + 1
+    ("_PLAID:", 8),    # len("_PLAID:") + 1
+    ("_MAN:", 6),      # len("_MAN:") + 1
+]
+
+_TABLES_WITH_TICKER = ["securities", "holdings", "daily_holding_values", "holding_lots"]
+
+
+def upgrade() -> None:
+    """Rewrite _SF:, _PLAID:, and _MAN: prefixes to _SYN: in all ticker columns."""
+    for prefix, substr_start in _OLD_PREFIXES:
+        for table in _TABLES_WITH_TICKER:
+            op.execute(
+                f"UPDATE {table} "
+                f"SET ticker = '_SYN:' || SUBSTR(ticker, {substr_start}) "
+                f"WHERE ticker LIKE '{prefix}%'"
+            )
+
+
+def downgrade() -> None:
+    """Reverse is not possible — we no longer know which prefix was original."""
+    pass

--- a/backend/integrations/plaid_client.py
+++ b/backend/integrations/plaid_client.py
@@ -57,10 +57,10 @@ def _generate_plaid_synthetic_symbol(security_id: str) -> str:
         security_id: The Plaid security_id for the holding.
 
     Returns:
-        A synthetic ticker in the format ``_PLAID:{hash8}``.
+        A synthetic ticker in the format ``_SYN:{hash8}``.
     """
     h = hashlib.sha256(security_id.encode()).hexdigest()[:8]
-    return f"_PLAID:{h}"
+    return f"_SYN:{h}"
 
 
 class PlaidClient:

--- a/backend/integrations/simplefin_client.py
+++ b/backend/integrations/simplefin_client.py
@@ -59,10 +59,10 @@ def _generate_synthetic_symbol(holding_id: str) -> str:
         holding_id: The SimpleFIN holding ID
 
     Returns:
-        A synthetic symbol in format _SF:{8-char-hash}
+        A synthetic symbol in format _SYN:{8-char-hash}
     """
     hash_hex = hashlib.sha256(holding_id.encode()).hexdigest()
-    return f"_SF:{hash_hex[:8]}"
+    return f"_SYN:{hash_hex[:8]}"
 
 
 class SimpleFINClient:

--- a/backend/scripts/cleanup_zero_value_holdings.py
+++ b/backend/scripts/cleanup_zero_value_holdings.py
@@ -30,7 +30,7 @@ def cleanup_zero_value_holdings(dry_run: bool = False):
         zero_value_holdings = (
             db.query(Holding)
             .filter(
-                Holding.ticker.like("_SF:%"),
+                Holding.ticker.like("_SYN:%"),
                 Holding.market_value <= Decimal("0"),
             )
             .all()

--- a/backend/services/manual_holdings_service.py
+++ b/backend/services/manual_holdings_service.py
@@ -25,11 +25,11 @@ MANUAL_PROVIDER_NAME = "Manual"
 def generate_manual_synthetic_ticker(description: str, unique_id: str) -> str:
     """Generate a synthetic ticker for a description-based holding.
 
-    Format: _MAN:{12-hex-chars} (SHA256 of description:unique_id)
+    Format: _SYN:{12-hex-chars} (SHA256 of description:unique_id)
     """
     raw = f"{description}:{unique_id}"
     hex_hash = hashlib.sha256(raw.encode()).hexdigest()[:12]
-    return f"_MAN:{hex_hash}"
+    return f"_SYN:{hex_hash}"
 
 
 class ManualHoldingsService:
@@ -139,7 +139,7 @@ class ManualHoldingsService:
                 db,
                 h_data["ticker"],
                 name=h_data.get("description"),
-                update_name=h_data["ticker"].startswith("_MAN:"),
+                update_name=h_data["ticker"].startswith("_SYN:"),
             )
 
             holding = Holding(
@@ -183,8 +183,8 @@ class ManualHoldingsService:
             "price": holding.snapshot_price,
             "market_value": holding.snapshot_value,
         }
-        # Preserve description for _MAN: holdings so Security.name stays current
-        if holding.ticker.startswith("_MAN:") and db is not None:
+        # Preserve description for _SYN: holdings so Security.name stays current
+        if holding.ticker.startswith("_SYN:") and db is not None:
             security = db.query(Security).filter_by(ticker=holding.ticker).first()
             if security:
                 result["description"] = security.name
@@ -226,7 +226,7 @@ class ManualHoldingsService:
         description: str,
         current_tickers: set[str],
     ) -> Optional[str]:
-        """Find an existing _MAN: Security whose name matches the description.
+        """Find an existing _SYN: Security whose name matches the description.
 
         Reusing the ticker preserves asset classification history when a
         holding is deleted and later re-added with the same description.
@@ -237,7 +237,7 @@ class ManualHoldingsService:
         existing = (
             db.query(Security)
             .filter(
-                Security.ticker.startswith("_MAN:"),
+                Security.ticker.startswith("_SYN:"),
                 Security.name == description,
             )
             .first()
@@ -360,8 +360,8 @@ class ManualHoldingsService:
         for h in current:
             if h.id == holding_id:
                 found = True
-                # For Other mode edits, reuse the existing _MAN: ticker
-                existing_ticker = h.ticker if h.ticker.startswith("_MAN:") else None
+                # For Other mode edits, reuse the existing _SYN: ticker
+                existing_ticker = h.ticker if h.ticker.startswith("_SYN:") else None
                 data = ManualHoldingsService._input_to_dict(
                     holding_input, existing_ticker=existing_ticker
                 )

--- a/backend/services/portfolio_valuation_service.py
+++ b/backend/services/portfolio_valuation_service.py
@@ -531,8 +531,7 @@ class PortfolioValuationService:
         symbols_to_fetch = [
             s for s in all_symbols
             if s.upper() not in CASH_TICKERS
-            and not s.startswith("_MAN:")
-            and not s.startswith("_SF:")
+            and not s.startswith("_SYN:")
             and not s.startswith("_CASH:")
         ]
         result.symbols_fetched = len(symbols_to_fetch)

--- a/backend/tests/integration/test_api_accounts.py
+++ b/backend/tests/integration/test_api_accounts.py
@@ -327,7 +327,7 @@ def test_get_account_holdings_with_synthetic_ticker(client: object, account, syn
 
     # Create a security with a synthetic ticker
     synthetic_security = Security(
-        ticker="_SF:abc12345",
+        ticker="_SYN:abc12345",
         name="Vanguard Target Retirement 2045",
     )
     db.add(synthetic_security)
@@ -345,7 +345,7 @@ def test_get_account_holdings_with_synthetic_ticker(client: object, account, syn
     holding = Holding(
         account_snapshot_id=acct_snap.id,
         security_id=synthetic_security.id,
-        ticker="_SF:abc12345",
+        ticker="_SYN:abc12345",
         quantity=Decimal("100.00"),
         snapshot_price=Decimal("50.00"),
         snapshot_value=Decimal("5000.00"),
@@ -357,7 +357,7 @@ def test_get_account_holdings_with_synthetic_ticker(client: object, account, syn
     assert response.status_code == 200
     data = response.json()
     assert len(data) == 1
-    assert data[0]["ticker"] == "_SF:abc12345"
+    assert data[0]["ticker"] == "_SYN:abc12345"
     assert data[0]["security_name"] == "Vanguard Target Retirement 2045"
 
 
@@ -602,7 +602,7 @@ def test_add_other_holding_via_api(client, manual_account):
     )
     assert response.status_code == 200
     data = response.json()
-    assert data["ticker"].startswith("_MAN:")
+    assert data["ticker"].startswith("_SYN:")
     assert Decimal(data["snapshot_value"]) == Decimal("500000")
 
 
@@ -638,7 +638,7 @@ def test_update_other_holding_via_api(client, manual_account):
     assert response.status_code == 200
     data = response.json()
     assert Decimal(data["snapshot_value"]) == Decimal("520000")
-    assert data["ticker"].startswith("_MAN:")
+    assert data["ticker"].startswith("_SYN:")
 
 
 def test_other_holding_visible_in_holdings_list(client, manual_account):
@@ -660,7 +660,7 @@ def test_other_holding_visible_in_holdings_list(client, manual_account):
     assert len(data) == 2
     tickers = {h["ticker"] for h in data}
     assert "VTI" in tickers
-    assert any(t.startswith("_MAN:") for t in tickers)
+    assert any(t.startswith("_SYN:") for t in tickers)
 
 
 # --- Account Type and Include in Allocation Tests ---

--- a/backend/tests/unit/test_holdings_delta.py
+++ b/backend/tests/unit/test_holdings_delta.py
@@ -220,15 +220,15 @@ class TestHoldingsDelta:
     def test_synthetic_ticker_shows_name(self, db, monkeypatch, capsys):
         acct = _make_account(db, "Test Account", ext_id="e1")
         # Use a synthetic ticker but give the security a recognizable name
-        get_or_create_security(db, "_SF:x1", "My CD Fund")
-        _make_dhv(db, acct, "_SF:x1", date(2026, 1, 15), Decimal("100"), Decimal("1"))
-        _make_dhv(db, acct, "_SF:x1", date(2026, 1, 16), Decimal("100"), Decimal("1.10"))
+        get_or_create_security(db, "_SYN:x1", "My CD Fund")
+        _make_dhv(db, acct, "_SYN:x1", date(2026, 1, 15), Decimal("100"), Decimal("1"))
+        _make_dhv(db, acct, "_SYN:x1", date(2026, 1, 16), Decimal("100"), Decimal("1.10"))
 
         output = self._run_delta(db, monkeypatch, capsys, date(2026, 1, 15), date(2026, 1, 16))
         # The detail table row should show security name, not the raw synthetic ticker
         detail_lines = [line for line in output.splitlines() if line.startswith("PRICE")]
         assert len(detail_lines) == 1
-        assert "_SF:x1" not in detail_lines[0]
+        assert "_SYN:x1" not in detail_lines[0]
         assert "My CD Fund" in detail_lines[0]
 
     def test_sort_by_ticker(self, db, monkeypatch, capsys):

--- a/backend/tests/unit/test_manual_holdings_service.py
+++ b/backend/tests/unit/test_manual_holdings_service.py
@@ -345,11 +345,11 @@ class TestManualHoldingInputValidation:
 class TestSyntheticTickerGeneration:
     def test_man_prefix(self):
         ticker = generate_manual_synthetic_ticker("Test", "abc")
-        assert ticker.startswith("_MAN:")
+        assert ticker.startswith("_SYN:")
 
     def test_length(self):
         ticker = generate_manual_synthetic_ticker("Test", "abc")
-        # _MAN: (5 chars) + 12 hex chars = 17 total
+        # _SYN: (5 chars) + 12 hex chars = 17 total
         assert len(ticker) == 17
 
     def test_uniqueness(self):
@@ -366,7 +366,7 @@ class TestOtherModeHoldings:
         )
         holding = ManualHoldingsService.add_holding(db, account, holding_input)
 
-        assert holding.ticker.startswith("_MAN:")
+        assert holding.ticker.startswith("_SYN:")
         assert holding.snapshot_value == Decimal("500000")
         assert holding.quantity == Decimal("1")
 
@@ -391,7 +391,7 @@ class TestOtherModeHoldings:
 
         # Update value
         current = ManualHoldingsService.get_current_holdings(db, account.id)
-        man_holding = [h for h in current if h.ticker.startswith("_MAN:")][0]
+        man_holding = [h for h in current if h.ticker.startswith("_SYN:")][0]
 
         updated = ManualHoldingsService.update_holding(
             db, account, man_holding.id,
@@ -410,7 +410,7 @@ class TestOtherModeHoldings:
         ticker = holding.ticker
 
         current = ManualHoldingsService.get_current_holdings(db, account.id)
-        man_holding = [h for h in current if h.ticker.startswith("_MAN:")][0]
+        man_holding = [h for h in current if h.ticker.startswith("_SYN:")][0]
 
         ManualHoldingsService.update_holding(
             db, account, man_holding.id,
@@ -452,7 +452,7 @@ class TestOtherModeHoldings:
 
         tickers = {h.ticker for h in current}
         assert "VTI" in tickers
-        assert any(t.startswith("_MAN:") for t in tickers)
+        assert any(t.startswith("_SYN:") for t in tickers)
 
     def test_readd_reuses_ticker_after_delete(self, db):
         """Deleting and re-adding with the same description reuses the ticker."""

--- a/backend/tests/unit/test_plaid_client.py
+++ b/backend/tests/unit/test_plaid_client.py
@@ -209,10 +209,10 @@ class TestSyntheticSymbol:
         assert s1 == s2
 
     def test_format(self):
-        """Symbol has _PLAID:{8 hex chars} format."""
+        """Symbol has _SYN:{8 hex chars} format."""
         symbol = _generate_plaid_synthetic_symbol("sec_abc")
-        assert symbol.startswith("_PLAID:")
-        assert len(symbol) == len("_PLAID:") + 8
+        assert symbol.startswith("_SYN:")
+        assert len(symbol) == len("_SYN:") + 8
 
     def test_different_ids_produce_different_symbols(self):
         s1 = _generate_plaid_synthetic_symbol("sec_aaa")
@@ -280,7 +280,7 @@ class TestMapHolding:
         result = client._map_holding(holding_data, securities_map)
 
         assert result is not None
-        assert result.symbol.startswith("_PLAID:")
+        assert result.symbol.startswith("_SYN:")
         assert result.name == "Target Fund"
         assert result.cost_basis is None
 

--- a/backend/tests/unit/test_security_service.py
+++ b/backend/tests/unit/test_security_service.py
@@ -49,12 +49,12 @@ class TestEnsureExists:
 
     def test_overwrites_name_when_update_name_true(self, db):
         """When update_name=True, overwrites the existing name."""
-        existing = Security(ticker="_MAN:abc123", name="Old Description")
+        existing = Security(ticker="_SYN:abc123", name="Old Description")
         db.add(existing)
         db.flush()
 
         security = SecurityService.ensure_exists(
-            db, "_MAN:abc123", "New Description", update_name=True
+            db, "_SYN:abc123", "New Description", update_name=True
         )
         assert security.name == "New Description"
 

--- a/backend/tests/unit/test_simplefin_client.py
+++ b/backend/tests/unit/test_simplefin_client.py
@@ -542,7 +542,7 @@ class TestSimpleFINClientProviderProtocol:
         assert len(holdings) == 2
 
         # Find the synthetic holding
-        synthetic = next(h for h in holdings if h.symbol.startswith("_SF:"))
+        synthetic = next(h for h in holdings if h.symbol.startswith("_SYN:"))
         assert synthetic.symbol == _generate_synthetic_symbol("hold_target_2045")
         assert synthetic.name == "Vanguard Target Retirement 2045"
         assert synthetic.market_value == Decimal("5000.0")
@@ -691,16 +691,16 @@ class TestSyntheticSymbolGeneration:
         symbol2 = _generate_synthetic_symbol(holding_id)
 
         assert symbol1 == symbol2
-        assert symbol1.startswith("_SF:")
-        assert len(symbol1) == 12  # "_SF:" (4) + 8 hex chars
+        assert symbol1.startswith("_SYN:")
+        assert len(symbol1) == 13  # "_SYN:" (5) + 8 hex chars
 
     def test_synthetic_symbol_format(self):
         """Synthetic symbols have correct format."""
         symbol = _generate_synthetic_symbol("test_id")
 
-        assert symbol.startswith("_SF:")
+        assert symbol.startswith("_SYN:")
         # Should be 8 hex characters after prefix
-        hex_part = symbol[4:]
+        hex_part = symbol[5:]
         assert len(hex_part) == 8
         # Verify it's valid hex
         int(hex_part, 16)
@@ -788,7 +788,7 @@ class TestSyntheticSymbolGeneration:
         symbols = {h.symbol for h in holdings}
         assert "SOLD" in symbols
         # h2 should have a synthetic symbol
-        synthetic = next(h for h in holdings if h.symbol.startswith("_SF:"))
+        synthetic = next(h for h in holdings if h.symbol.startswith("_SYN:"))
         assert synthetic.market_value == Decimal("5000.0")
 
 
@@ -880,7 +880,7 @@ class TestRealisticAPIResponse:
             holdings = client.get_holdings()
 
         # Find the 529 target date fund (no ticker symbol in response)
-        synthetic_holdings = [h for h in holdings if h.symbol.startswith("_SF:")]
+        synthetic_holdings = [h for h in holdings if h.symbol.startswith("_SYN:")]
         assert len(synthetic_holdings) == 1
 
         target_fund = synthetic_holdings[0]

--- a/backend/utils/ticker.py
+++ b/backend/utils/ticker.py
@@ -4,24 +4,19 @@ Mirrors frontend/src/utils/ticker.ts for consistent behavior.
 """
 
 ZERO_BALANCE_TICKER = "_ZERO_BALANCE"
+SYNTHETIC_PREFIX = "_SYN:"
 
 
 def is_synthetic_ticker(ticker: str) -> bool:
     """Check if ticker is a synthetic internal identifier.
 
     Synthetic tickers include:
-    - _SF:{hash}      — SimpleFIN provider for non-tradable holdings
-    - _MAN:{hash}     — Manual holdings for "Other" assets
+    - _SYN:{hash}     — Non-tradable holdings (any provider or manual)
     - _ZERO_BALANCE   — Sentinel for accounts with zero holdings
 
     These should generally be hidden from users in display contexts.
     """
-    return (
-        ticker.startswith("_SF:")
-        or ticker.startswith("_MAN:")
-        or ticker.startswith("_PLAID:")
-        or ticker == ZERO_BALANCE_TICKER
-    )
+    return ticker.startswith(SYNTHETIC_PREFIX) or ticker == ZERO_BALANCE_TICKER
 
 
 def is_cash_ticker(ticker: str) -> bool:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -315,8 +315,8 @@ See [Schema Design Rationale](#schema-design-rationale) above for detailed discu
 
 ### 3. Synthetic Tickers
 
-Non-tradable assets (SimpleFIN manual holdings, brokerage cash) get synthetic tickers:
-- Format: `_SF:{hash}` (SimpleFIN), `_MAN:{hash}` (manual)
+Non-tradable assets (provider holdings without symbols, manual "Other" holdings) get synthetic tickers:
+- Format: `_SYN:{hash}` (unified prefix for all providers and manual holdings)
 - Allows treating all holdings uniformly in the database
 - Hidden from user in UI (detected via `isSyntheticTicker()` utility)
 

--- a/docs/sync-and-valuation.md
+++ b/docs/sync-and-valuation.md
@@ -307,7 +307,7 @@ Called on startup and before every sync. Fills from the last DHV date through ye
 
 5. Filter non-market symbols
    ├── Remove cash tickers (USD, CASH, CAD, SPAXX, etc.)
-   ├── Remove synthetic tickers (_SF:*, _MAN:*, _ZERO_BALANCE)
+   ├── Remove synthetic tickers (_SYN:*, _ZERO_BALANCE)
    └── Detect crypto symbols (securities classified under "Crypto" asset class)
 
 6. Fetch market data
@@ -427,7 +427,7 @@ For each holding on each day, the system resolves a price using this cascade:
    └── Or _CASH: prefix (e.g., _CASH:USD from Coinbase)
    → Always $1.00
 
-2. Synthetic ticker? (_SF:*, _MAN:*, _ZERO_BALANCE)
+2. Synthetic ticker? (_SYN:*, _ZERO_BALANCE)
    → Use snapshot_price (no market data exists for these)
 
 3. Market data available?
@@ -499,7 +499,8 @@ SQLite's `BEGIN IMMEDIATE` transaction mode serializes these operations at the d
 
 Non-tradable "Other" holdings (described by name, not ticker) get synthetic tickers:
 
-- Format: `_MAN:{12-hex-chars}` (SHA-256 of `description:unique_id`)
+- Format: `_SYN:{12-hex-chars}` (SHA-256 of `description:unique_id`)
+- Same `_SYN:` prefix used by all providers (SimpleFIN, Plaid) and manual holdings
 - Stored as quantity=1, price=market_value (since there's no per-share price)
 - If a holding is deleted and re-added with the same description, the original ticker is reused (preserves asset classification history)
 - Hidden from users in the UI via `isSyntheticTicker()` utility

--- a/frontend/src/__tests__/components/HoldingFormModal.test.tsx
+++ b/frontend/src/__tests__/components/HoldingFormModal.test.tsx
@@ -25,7 +25,7 @@ const mockHolding = {
 const mockManualHolding = {
   id: "h-man-1",
   account_snapshot_id: "acct-snap-1",
-  ticker: "_MAN:abc12345",
+  ticker: "_SYN:abc12345",
   quantity: 1,
   snapshot_price: 500000,
   snapshot_value: 500000,
@@ -384,7 +384,7 @@ describe("HoldingFormModal", () => {
       expect(accountsApi.addHolding).not.toHaveBeenCalled();
     });
 
-    it("auto-selects Other mode and pre-populates description when editing _MAN: holding", () => {
+    it("auto-selects Other mode and pre-populates description when editing _SYN: holding", () => {
       render(
         <HoldingFormModal
           isOpen={true}

--- a/frontend/src/__tests__/pages/AccountDetails.test.tsx
+++ b/frontend/src/__tests__/pages/AccountDetails.test.tsx
@@ -426,12 +426,12 @@ describe("AccountDetailsPage", () => {
       expect(screen.getByText("No holdings found. Sync required.")).toBeInTheDocument();
     });
 
-    it("shows description and hides ticker for _MAN: holdings", async () => {
+    it("shows description and hides ticker for _SYN: manual holdings", async () => {
       const manualHoldingsWithOther = [
         {
           id: "h-man-1",
           account_snapshot_id: "acct-snap-1",
-          ticker: "_MAN:abc12345",
+          ticker: "_SYN:abc12345",
           security_name: "Primary Residence",
           quantity: "1",
           snapshot_price: "500000",
@@ -453,15 +453,15 @@ describe("AccountDetailsPage", () => {
       // Description should be shown
       expect(screen.getByText("Primary Residence")).toBeInTheDocument();
       // Synthetic ticker should NOT be shown
-      expect(screen.queryByText("_MAN:abc12345")).not.toBeInTheDocument();
+      expect(screen.queryByText("_SYN:abc12345")).not.toBeInTheDocument();
     });
 
-    it("shows description and hides ticker for _SF: holdings", async () => {
+    it("shows description and hides ticker for _SYN: provider holdings", async () => {
       const simplefinHoldingsWithSynthetic = [
         {
           id: "h-sf-1",
           account_snapshot_id: "acct-snap-1",
-          ticker: "_SF:xyz98765",
+          ticker: "_SYN:xyz98765",
           security_name: "Vanguard Target Trust 529",
           quantity: "100",
           snapshot_price: "150.50",
@@ -483,15 +483,15 @@ describe("AccountDetailsPage", () => {
       // Description should be shown
       expect(screen.getByText("Vanguard Target Trust 529")).toBeInTheDocument();
       // Synthetic ticker should NOT be shown
-      expect(screen.queryByText("_SF:xyz98765")).not.toBeInTheDocument();
+      expect(screen.queryByText("_SYN:xyz98765")).not.toBeInTheDocument();
     });
 
-    it("shows dash for quantity and price of _MAN: holdings", async () => {
+    it("shows dash for quantity and price of _SYN: holdings", async () => {
       const manualHoldingsWithOther = [
         {
           id: "h-man-1",
           account_snapshot_id: "acct-snap-1",
-          ticker: "_MAN:abc12345",
+          ticker: "_SYN:abc12345",
           security_name: "Primary Residence",
           quantity: "1",
           snapshot_price: "500000",

--- a/frontend/src/__tests__/pages/AssetTypeDetails.test.tsx
+++ b/frontend/src/__tests__/pages/AssetTypeDetails.test.tsx
@@ -193,7 +193,7 @@ describe("AssetTypeDetailsPage", () => {
     expect(rows[1].className).not.toContain("bg-tf-bg-secondary");
   });
 
-  it("shows em-dash for _MAN: synthetic tickers", async () => {
+  it("shows em-dash for _SYN: manual synthetic tickers", async () => {
     const detailWithSynthetic = {
       ...mockDetail,
       holdings: [
@@ -201,7 +201,7 @@ describe("AssetTypeDetailsPage", () => {
           holding_id: "h-3",
           account_id: "acc-3",
           account_name: "Manual Account",
-          ticker: "_MAN:abc123456789",
+          ticker: "_SYN:abc123456789",
           security_name: "Primary Residence",
           market_value: "500000.00",
         },
@@ -219,7 +219,7 @@ describe("AssetTypeDetailsPage", () => {
     expect(screen.getByText("Primary Residence")).toBeInTheDocument();
 
     // Synthetic ticker should NOT be displayed
-    expect(screen.queryByText("_MAN:abc123456789")).not.toBeInTheDocument();
+    expect(screen.queryByText("_SYN:abc123456789")).not.toBeInTheDocument();
 
     // Em-dash should be shown in ticker column (first column)
     const rows = screen.getAllByRole("row");
@@ -227,7 +227,7 @@ describe("AssetTypeDetailsPage", () => {
     expect(groupHeaderCells[0].textContent).toBe("—");
   });
 
-  it("shows em-dash for _SF: synthetic tickers", async () => {
+  it("shows em-dash for _SYN: provider synthetic tickers", async () => {
     const detailWithSynthetic = {
       ...mockDetail,
       holdings: [
@@ -235,7 +235,7 @@ describe("AssetTypeDetailsPage", () => {
           holding_id: "h-4",
           account_id: "acc-4",
           account_name: "529 Plan",
-          ticker: "_SF:xyz98765",
+          ticker: "_SYN:xyz98765",
           security_name: "Vanguard Target Trust",
           market_value: "50000.00",
         },
@@ -253,7 +253,7 @@ describe("AssetTypeDetailsPage", () => {
     expect(screen.getByText("Vanguard Target Trust")).toBeInTheDocument();
 
     // Synthetic ticker should NOT be displayed
-    expect(screen.queryByText("_SF:xyz98765")).not.toBeInTheDocument();
+    expect(screen.queryByText("_SYN:xyz98765")).not.toBeInTheDocument();
 
     // Em-dash should be shown in ticker column (first column)
     const rows = screen.getAllByRole("row");

--- a/frontend/src/__tests__/utils/ticker.test.ts
+++ b/frontend/src/__tests__/utils/ticker.test.ts
@@ -7,19 +7,10 @@ import {
 
 describe("ticker utilities", () => {
   describe("isSyntheticTicker", () => {
-    it("returns true for _SF: prefixed tickers", () => {
-      expect(isSyntheticTicker("_SF:abc12345")).toBe(true);
-      expect(isSyntheticTicker("_SF:12345678")).toBe(true);
-    });
-
-    it("returns true for _MAN: prefixed tickers", () => {
-      expect(isSyntheticTicker("_MAN:abc123456789")).toBe(true);
-      expect(isSyntheticTicker("_MAN:123456789012")).toBe(true);
-    });
-
-    it("returns true for _PLAID: prefixed tickers", () => {
-      expect(isSyntheticTicker("_PLAID:abc12345")).toBe(true);
-      expect(isSyntheticTicker("_PLAID:12345678")).toBe(true);
+    it("returns true for _SYN: prefixed tickers", () => {
+      expect(isSyntheticTicker("_SYN:abc12345")).toBe(true);
+      expect(isSyntheticTicker("_SYN:12345678")).toBe(true);
+      expect(isSyntheticTicker("_SYN:abc123456789")).toBe(true);
     });
 
     it("returns false for regular tickers", () => {
@@ -41,6 +32,12 @@ describe("ticker utilities", () => {
     it("returns false for empty string", () => {
       expect(isSyntheticTicker("")).toBe(false);
     });
+
+    it("returns false for old prefixes", () => {
+      expect(isSyntheticTicker("_SF:abc12345")).toBe(false);
+      expect(isSyntheticTicker("_MAN:abc123456789")).toBe(false);
+      expect(isSyntheticTicker("_PLAID:abc12345")).toBe(false);
+    });
   });
 
   describe("isCashTicker", () => {
@@ -56,8 +53,8 @@ describe("ticker utilities", () => {
     });
 
     it("returns false for synthetic tickers", () => {
-      expect(isCashTicker("_SF:abc12345")).toBe(false);
-      expect(isCashTicker("_MAN:abc123456789")).toBe(false);
+      expect(isCashTicker("_SYN:abc12345")).toBe(false);
+      expect(isCashTicker("_SYN:abc123456789")).toBe(false);
     });
 
     it("returns false for empty string", () => {

--- a/frontend/src/pages/AccountDetails.tsx
+++ b/frontend/src/pages/AccountDetails.tsx
@@ -192,10 +192,10 @@ export function AccountDetailsPage() {
                     </div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-tf-text-tertiary">
-                    {h.ticker.startsWith("_MAN:") ? "-" : Number(h.quantity).toLocaleString()}
+                    {isSyntheticTicker(h.ticker) ? "-" : Number(h.quantity).toLocaleString()}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm text-tf-text-tertiary">
-                    {h.ticker.startsWith("_MAN:") ? "-" : `$${Number(h.market_price ?? h.snapshot_price).toLocaleString(undefined, {
+                    {isSyntheticTicker(h.ticker) ? "-" : `$${Number(h.market_price ?? h.snapshot_price).toLocaleString(undefined, {
                       minimumFractionDigits: 2,
                     })}`}
                   </td>

--- a/frontend/src/utils/ticker.ts
+++ b/frontend/src/utils/ticker.ts
@@ -3,23 +3,18 @@
  */
 
 export const ZERO_BALANCE_TICKER = "_ZERO_BALANCE";
+export const SYNTHETIC_PREFIX = "_SYN:";
 
 /**
  * Checks if a ticker is a synthetic internal identifier.
  * Synthetic tickers include:
- * - _SF:{hash} - SimpleFIN provider for non-tradable holdings
- * - _MAN:{hash} - Manual holdings for "Other" assets
+ * - _SYN:{hash} - Non-tradable holdings (any provider or manual)
  * - _ZERO_BALANCE - Sentinel for accounts with zero holdings
  *
  * These should generally be hidden from users in UI views.
  */
 export function isSyntheticTicker(ticker: string): boolean {
-  return (
-    ticker.startsWith("_SF:") ||
-    ticker.startsWith("_MAN:") ||
-    ticker.startsWith("_PLAID:") ||
-    ticker === ZERO_BALANCE_TICKER
-  );
+  return ticker.startsWith(SYNTHETIC_PREFIX) || ticker === ZERO_BALANCE_TICKER;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replace three per-provider synthetic prefixes (`_SF:`, `_PLAID:`, `_MAN:`) with a single `_SYN:` prefix
- Simplify `is_synthetic_ticker()` / `isSyntheticTicker()` to a single `startsWith("_SYN:")` check in both backend and frontend
- Add Alembic migration to rewrite existing tickers in `securities`, `holdings`, `daily_holding_values`, and `holding_lots` tables
- Update all tests, documentation, and UI references

Closes #8

## Test plan

- [x] All 1661 backend tests pass
- [x] All 476 frontend tests pass
- [x] Ruff, ESLint, and TypeScript type-check all clean
- [x] Alembic migration applies cleanly (`alembic upgrade head`)
- [ ] Manually verify existing synthetic holdings display correctly after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)