### PR TITLE
Filter $ and $$ cash symbols from yfinance downloads

### DIFF
--- a/backend/services/portfolio_valuation_service.py
+++ b/backend/services/portfolio_valuation_service.py
@@ -50,7 +50,7 @@ class PriceWithDate(NamedTuple):
 
 # Tickers treated as cash equivalents (always priced at $1.00).
 CASH_TICKERS = frozenset({
-    "USD", "CASH", "CAD",
+    "$", "$$", "USD", "CASH", "CAD",
     # Common money market / sweep funds
     "SPAXX", "FDRXX", "SWVXX", "VMFXX", "FZFXX",
 })


### PR DESCRIPTION
## Summary
- Add `$` and `$$` to `CASH_TICKERS` in `portfolio_valuation_service.py` so they are excluded from yfinance market data fetches
- Some brokerages (e.g. Altruist via SimpleFIN) report cash positions with bare `$` symbols. These were already filtered during sync ingestion but not excluded from the market data fetch list, causing yfinance 404 errors during daily history backfill.

## Test plan
- [x] Existing `TestIsCashEquivalent.test_known_cash_tickers` iterates over all `CASH_TICKERS` and now covers `$` and `$$`
- [x] All 129 portfolio valuation service tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)